### PR TITLE
Fix coveralls to exclude guis folder

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+omit = */guis/*


### PR DESCRIPTION
Exclude the whole gui stuff from coverage for now...
Maybe this could be included at a later point to some degree
