### PR TITLE
LST2CRD proposes channel(s) for signals if user chose wrong

### DIFF
--- a/rimseval/data_io/lst_to_crd.py
+++ b/rimseval/data_io/lst_to_crd.py
@@ -85,6 +85,7 @@ class LST2CRD:
         self._data_format = None  # format of the data. auto set on reading
         self._data_signal = None  # data for signal (total)
         self._tags = None  # array for tagged shots
+        self._other_channels = None  # List for other channels that have counts
 
     # PROPERTIES #
 
@@ -264,13 +265,14 @@ class LST2CRD:
         self.set_data_format()
 
         if data_type.lower() == "asc":
-            data_sig, tags = lst_utils.ascii_to_ndarray(
+            data_sig, tags, other_channels = lst_utils.ascii_to_ndarray(
                 data_ascii, self._data_format, self.channel_data, self.channel_tag
             )
         else:
             raise NotImplementedError("Binary data is currently not supported.")
         self._data_signal = data_sig
         self._tags = tags
+        self._other_channels = other_channels
 
         # set number of ions
         self._file_info["no_ions"] = len(data_sig)
@@ -290,8 +292,9 @@ class LST2CRD:
 
         if self._data_signal.shape[0] == 0:
             raise OSError(
-                "There are no counts present in this file. Please double "
-                "check that you are using the correct channel for the signal."
+                f"There are no counts present in this file. Please double "
+                f"check that you are using the correct channel for the signal. "
+                f"The file seems to have counts in channels {self._other_channels}."
             )
 
         # calculate the maximum number of sweeps that can be recorded

--- a/rimseval/data_io/lst_utils.py
+++ b/rimseval/data_io/lst_utils.py
@@ -10,7 +10,7 @@ from .lst_to_crd import LST2CRD
 
 def ascii_to_ndarray(
     data_list: List[str], fmt: LST2CRD.ASCIIFormat, channel: int, tag: int = None
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> Tuple[np.ndarray, np.ndarray, List]:
     """Turn ASCII LST data to a numpy array.
 
     Takes the whole data block and returns the data in a properly formatted numpy array.
@@ -21,7 +21,7 @@ def ascii_to_ndarray(
     :param channel: Channel the data is in
     :param tag: Channel the tag is in, or None if no tag
 
-    :return: Data, Tag Data
+    :return: Data, Tag Data, Other Channels available
     """
     # prepare the data and list
     data_arr = np.empty((len(data_list), 2), dtype=np.uint32)
@@ -41,6 +41,8 @@ def ascii_to_ndarray(
 
     tag_counter = 0
 
+    other_channels = []
+
     # transform to bin number with correct length
     for data in data_list:
         if data != "":
@@ -58,12 +60,15 @@ def ascii_to_ndarray(
                 swp_val, _ = get_sweep_time_ascii(bin_tmp, boundaries[0], boundaries[1])
                 data_arr_tag[tag_counter] = swp_val
                 tag_counter += 1
+            elif tmp_channel != 0:
+                if tmp_channel not in other_channels:
+                    other_channels.append(tmp_channel)
 
     data_arr = data_arr[:ion_counter]
     if tag is not None:
         data_arr_tag = data_arr_tag[:tag_counter]
 
-    return data_arr, data_arr_tag
+    return data_arr, data_arr_tag, other_channels
 
 
 def get_sweep_time_ascii(

--- a/rimseval/data_io/lst_utils.py
+++ b/rimseval/data_io/lst_utils.py
@@ -14,7 +14,8 @@ def ascii_to_ndarray(
     """Turn ASCII LST data to a numpy array.
 
     Takes the whole data block and returns the data in a properly formatted numpy array.
-    For speed, using numba JITing.
+    If channels other than the selected ones are available, these are written to a
+    List and also returned as ``other_channels``.
 
     :param data_list: Data, directly supplied from the TDC block.
     :param fmt: Format of the data

--- a/tests/func/data_io/test_lst_utils.py
+++ b/tests/func/data_io/test_lst_utils.py
@@ -20,7 +20,7 @@ def test_ascii_to_ndarray_ascii_1a_no_tag(init_lst_proc):
     channel = 4
     expected_return = np.array([[1, 59207], [2, 59207], [3, 59207]], dtype=np.uint32)
 
-    ret_data, ret_tag = utl.ascii_to_ndarray(data_list, fmt, channel)
+    ret_data, ret_tag, _ = utl.ascii_to_ndarray(data_list, fmt, channel)
     np.testing.assert_equal(ret_data, expected_return)
     assert ret_tag is None
 
@@ -40,10 +40,27 @@ def test_ascii_to_ndarray_ascii_1a_tag(init_lst_proc):
     expected_data = np.array([[1, 59207], [2, 59207], [3, 59207]], dtype=np.uint32)
     expected_tag = np.array([2], dtype=np.uint32)
 
-    ret_data, ret_tag = utl.ascii_to_ndarray(data_list, fmt, channel, tag)
+    ret_data, ret_tag, _ = utl.ascii_to_ndarray(data_list, fmt, channel, tag)
 
     np.testing.assert_equal(ret_data, expected_data)
     np.testing.assert_equal(ret_tag, expected_tag)
+
+
+def test_ascii_to_ndarray_ascii_1a_no_tag_other_channel(init_lst_proc):
+    """Convert ASCII_1A, data to numpy array, w/o tag."""
+    data_list = [
+        "0001000e7474",
+        "0002000e7474",
+        "0002000e7473",  # wrong channel
+        "0003000e7474",
+        "000000000000",  # zero
+    ]
+    fmt = init_lst_proc.ASCIIFormat.ASC_1A
+    other_channels_exp = [4]
+    channel = 3
+
+    _, _, other_channels_ret = utl.ascii_to_ndarray(data_list, fmt, channel)
+    assert other_channels_ret == other_channels_exp
 
 
 def test_get_sweep_time_ascii():

--- a/tests/unit/data_io/test_lst_to_crd.py
+++ b/tests/unit/data_io/test_lst_to_crd.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from rimseval.data_io import LST2CRD
 
 
@@ -61,4 +63,26 @@ def test_mcs8a_short_10k(tmpdir, lst_crd_path):
     assert (
         Path(tmpdir.strpath).joinpath(crd_fname).read_bytes()
         == lst_crd_path.joinpath(crd_fname).read_bytes()
+    )
+
+
+def test_mcs8a_short_10k_wrong_channel(tmpdir, lst_crd_path):
+    """Raise OSError and propose the correct channel to user"""
+    lst_fname = "MCS8a_short_10k_signal.lst"
+    other_channels = [9]
+
+    # copy file to temporary file
+    tmpdir.join(lst_fname).write_binary(lst_crd_path.joinpath(lst_fname).read_bytes())
+    lst_fpath = Path(tmpdir.strpath).joinpath(lst_fname)
+
+    # create crd
+    conv = LST2CRD(file_name=lst_fpath, channel_data=7)
+    conv.read_list_file()
+    with pytest.raises(OSError) as err:
+        conv.write_crd()
+    msg = err.value.args[0]
+    assert msg == (
+        f"There are no counts present in this file. Please double "
+        f"check that you are using the correct channel for the signal. "
+        f"The file seems to have counts in channels {other_channels}."
     )

--- a/tests/unit/data_io/test_lst_to_crd.py
+++ b/tests/unit/data_io/test_lst_to_crd.py
@@ -66,7 +66,7 @@ def test_mcs8a_short_10k(tmpdir, lst_crd_path):
     )
 
 
-def test_mcs8a_short_10k_wrong_channel(tmpdir, lst_crd_path):
+def test_mcs8a_short_10k_wrong_channel_error_message(tmpdir, lst_crd_path):
     """Raise OSError and propose the correct channel to user"""
     lst_fname = "MCS8a_short_10k_signal.lst"
     other_channels = [9]


### PR DESCRIPTION
If no data can be found in the signal channel that the user selected,
the LST converter now proposes which channels the signal might be in.
It goes through the LST files and proposes all channels that seem to
have counts. This can still result in wrong channels, 
however it should narrow the search for the user.
