### PR TITLE
BF: Create tof data from arrival bins when bin ranges in header wrong

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
     "flake8-bugbear",
     "flake8-docstrings",
     "flake8-import-order",
+    "bandit==1.7.2"
 ]
 doc = [
     "sphinx",

--- a/rimseval/processor.py
+++ b/rimseval/processor.py
@@ -747,7 +747,10 @@ class CRDFileProcessor:
                 "Bin ranges in CRD file were of bad length. Creating ToF "
                 "array without CRD header input."
             )
-            self.tof = np.arange(len(self.data)) * bin_length / 1e6
+            self.tof = (
+                np.arange(len(self.data)) * bin_length / 1e6
+                + self.all_tofs.min() / self.us_to_chan
+            )
 
     def spectrum_part(self, rng: Union[Tuple[Any], List[Any]]) -> None:
         """Create ToF for a part of the spectra.


### PR DESCRIPTION
Previous CRD files created by `LIONEval` have bad header data, i.e., the bin ranges are incorrect. In that case, the program recreated the whole tof data by just assuming that the first ion that hit is at zero ToF. Now we are correcting this by offsetting with the first ion arrival bin's time of flight. 

This fixes a bug that made the ToF spectra of old files be misaligned, i.e., the absolute tof depended on the arrival time of the first ion, which is not generally the same from measurement to measurement.
