### PR TITLE
Add method to sort integrals

### DIFF
--- a/rimseval/processor.py
+++ b/rimseval/processor.py
@@ -741,6 +741,28 @@ class CRDFileProcessor:
 
         sys.path.remove(str(file_path))
 
+    def sort_integrals(self) -> None:
+        """Sort all the integrals that are defined by mass.
+
+        Takes the integrals and the names and sorts them by mass. The starting mass
+        of each integral is used for sorting.
+        If no integrals are defined, this routine does nothing.
+
+        Example:
+            >>> crd.def_integrals
+            ["Fe-56", "Ti-46"], array([[55.8, 56.2], [45.8, 46.2]])
+            >>> crd.sort_integrals()
+            >>> crd.def_integrals
+            ["Ti-46", "Fe-56"], array([[45.8, 46.2], [55.8, 56.2]])
+        """
+        if self.def_integrals is None:
+            return
+
+        names, values = self.def_integrals
+        sort_ind = values[:, 0].argsort()
+        names_sorted = list(np.array(names)[sort_ind])
+        self.def_integrals = names_sorted, values[sort_ind]
+
     def spectrum_full(self) -> None:
         """Create ToF and summed ion count array for the full spectrum.
 

--- a/rimseval/processor.py
+++ b/rimseval/processor.py
@@ -741,12 +741,14 @@ class CRDFileProcessor:
 
         sys.path.remove(str(file_path))
 
-    def sort_integrals(self) -> None:
+    def sort_integrals(self, sort_vals: bool = True) -> None:
         """Sort all the integrals that are defined by mass.
 
         Takes the integrals and the names and sorts them by mass. The starting mass
         of each integral is used for sorting.
         If no integrals are defined, this routine does nothing.
+
+        :param sort_vals: Sort the integrals and integral packages? Default: True
 
         Example:
             >>> crd.def_integrals
@@ -767,9 +769,9 @@ class CRDFileProcessor:
         names_sorted = list(np.array(names)[sort_ind])
         self.def_integrals = names_sorted, values[sort_ind]
 
-        if self.integrals is not None:
+        if self.integrals is not None and sort_vals:
             self.integrals = self.integrals[sort_ind]
-        if self.integrals_pkg is not None:
+        if self.integrals_pkg is not None and sort_vals:
             self.integrals_pkg = self.integrals_pkg[:, sort_ind]
 
     def spectrum_full(self) -> None:

--- a/rimseval/processor.py
+++ b/rimseval/processor.py
@@ -760,8 +760,17 @@ class CRDFileProcessor:
 
         names, values = self.def_integrals
         sort_ind = values[:, 0].argsort()
+
+        if (sort_ind == np.arange(len(names))).all():  # already sorted
+            return
+
         names_sorted = list(np.array(names)[sort_ind])
         self.def_integrals = names_sorted, values[sort_ind]
+
+        if self.integrals is not None:
+            self.integrals = self.integrals[sort_ind]
+        if self.integrals_pkg is not None:
+            self.integrals_pkg = self.integrals_pkg[:, sort_ind]
 
     def spectrum_full(self) -> None:
         """Create ToF and summed ion count array for the full spectrum.

--- a/tests/func/test_processor.py
+++ b/tests/func/test_processor.py
@@ -220,12 +220,21 @@ def test_sort_integrals(crd_file):
     crd = CRDFileProcessor(Path(fname))
     crd.sort_integrals()  # does nothing, since None
     crd.def_integrals = ["Fe-56", "Ti-46"], np.array([[55.8, 56.2], [45.8, 46.2]])
+
+    crd.integrals = np.array([[2, 2], [1, 1]])
+    crd.integrals_pkg = np.array([crd.integrals, crd.integrals - 1])
+
     names_exp = ["Ti-46", "Fe-56"]
     values_exp = np.array([[45.8, 46.2], [55.8, 56.2]])
+    integrals_exp = np.array([[1, 1], [2, 2]])
+    integrals_pkg_exp = np.array([[[1, 1], [2, 2]], [[0, 0], [1, 1]]])
+
     crd.sort_integrals()
     names_rec, values_rec = crd.def_integrals
     assert names_rec == names_exp
     np.testing.assert_equal(values_rec, values_exp)
+    np.testing.assert_equal(crd.integrals, integrals_exp)
+    np.testing.assert_equal(crd.integrals_pkg, integrals_pkg_exp)
 
 
 def test_spectrum_part(crd_file):

--- a/tests/func/test_processor.py
+++ b/tests/func/test_processor.py
@@ -214,6 +214,20 @@ def test_packages(crd_file):
     assert crd.nof_shots_pkg.sum() == crd.nof_shots
 
 
+def test_sort_integrals(crd_file):
+    """Sort integrals by first mass."""
+    _, _, _, fname = crd_file
+    crd = CRDFileProcessor(Path(fname))
+    crd.sort_integrals()  # does nothing, since None
+    crd.def_integrals = ["Fe-56", "Ti-46"], np.array([[55.8, 56.2], [45.8, 46.2]])
+    names_exp = ["Ti-46", "Fe-56"]
+    values_exp = np.array([[45.8, 46.2], [55.8, 56.2]])
+    crd.sort_integrals()
+    names_rec, values_rec = crd.def_integrals
+    assert names_rec == names_exp
+    np.testing.assert_equal(values_rec, values_exp)
+
+
 def test_spectrum_part(crd_file):
     """Cut spectrum by two shots."""
     _, ions_per_shot, _, fname = crd_file


### PR DESCRIPTION
Use `sort_integrals` in the `CRDFileProcessor` to sort the integrals and their names according to the start mass of the integral.
