### PR TITLE
Add timestamp property to CRDFileProcessor

### DIFF
--- a/rimseval/processor.py
+++ b/rimseval/processor.py
@@ -3,6 +3,7 @@
 Note: Interfacing with external files is done in the `interfacer.py` library.
 """
 
+import datetime
 from pathlib import Path
 import sys
 from typing import Any, List, Tuple, Union
@@ -210,6 +211,21 @@ class CRDFileProcessor:
     @peak_fwhm.setter
     def peak_fwhm(self, value: float) -> None:
         self._peak_fwhm = value
+
+    @property
+    def timestamp(self) -> datetime.datetime:
+        """Get the time stamp when the recording was started.
+
+        :return: Timestamp of the CRD file.
+
+        Example:
+            >>> crd = CRDFileProcessor(Path("my_file.crd"))
+            >>> crd.timestamp
+
+        """
+        hdr_timestamp = self.crd.header["startDateTime"].rstrip(b"\x00").decode("utf-8")
+        dt = datetime.datetime.strptime(hdr_timestamp, "%Y:%m:%d %H:%M:%S")
+        return dt
 
     @property
     def us_to_chan(self) -> float:

--- a/rimseval/processor.py
+++ b/rimseval/processor.py
@@ -221,7 +221,7 @@ class CRDFileProcessor:
         Example:
             >>> crd = CRDFileProcessor(Path("my_file.crd"))
             >>> crd.timestamp
-
+            datetime.datetime(2021, 7, 10, 11, 41, 13)
         """
         hdr_timestamp = self.crd.header["startDateTime"].rstrip(b"\x00").decode("utf-8")
         dt = datetime.datetime.strptime(hdr_timestamp, "%Y:%m:%d %H:%M:%S")

--- a/tests/func/test_processor.py
+++ b/tests/func/test_processor.py
@@ -1,5 +1,6 @@
 """Function test for processor class methods, focusing on each function."""
 
+import datetime
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,19 @@ import numpy as np
 
 from rimseval.processor import CRDFileProcessor
 import rimseval.processor_utils as pu
+
+# TEST PROPERTIES #
+
+
+def test_timestamp(crd_file):
+    """Get the time stamp of the CRD file as a python datetime."""
+    _, _, _, fname = crd_file
+    crd = CRDFileProcessor(Path(fname))
+    timestamp = crd.timestamp
+    assert isinstance(timestamp, datetime.datetime)
+
+
+# TEST METHODS #
 
 
 def test_data_dimension_after_dead_time_correction(crd_file):


### PR DESCRIPTION
Add a property to the `CRDFileProcessor` that allows us to return the timestamp on when the recording of the spectrum started as a python `datetime.datetime` type. This can be used to:

 - copy the recording time as an ISO conform time string (Excel, etc.)
 - calculate time deltas easily
