### PR TITLE
DOCS: Add instructions remove arguments from macOS app

### DIFF
--- a/docs/gui/install.rst
+++ b/docs/gui/install.rst
@@ -12,7 +12,7 @@ download the latest release version for your operating system from
 You do not need to have an existing python environment,
 since all dependencies will be installed along.
 
-.. warning:: Issues on macOS
+.. note:: Issues on macOS
 
     Once you moved the `RIMSEvaluation` program from the `dmg` archive
     into your `Applications` folder, your macOS might still tell you

--- a/docs/gui/install.rst
+++ b/docs/gui/install.rst
@@ -20,10 +20,10 @@ since all dependencies will be installed along.
     moved to the trash.
     This happens since the program is not officially signed
     with a valid Apple ID account.
-    More information can be found
-    in [this issue](https://github.com/RIMS-Code/RIMSEvalGUI/issues/9).
+    More information can be found in
+    `this issue <https://github.com/RIMS-Code/RIMSEvalGUI/issues/9>`_.
     To still use the `RIMSEvaluation` executable,
-    open a terminal and type the following command:
+    open a terminal and run the following command:
 
     .. code-block::
 

--- a/docs/gui/install.rst
+++ b/docs/gui/install.rst
@@ -12,9 +12,28 @@ download the latest release version for your operating system from
 You do not need to have an existing python environment,
 since all dependencies will be installed along.
 
-.. note:: The executable is great for a working, bug-free program.
-    If you want to help debugging, it is recommended that you run the software
-    either from Anaconda (see below) or from regular Python directly.
+.. warning:: Issues on macOS
+
+    Once you moved the `RIMSEvaluation` program from the `dmg` archive
+    into your `Applications` folder, your macOS might still tell you
+    that when opening the program that it is damaged and needs to be
+    moved to the trash.
+    This happens since the program is not officially signed
+    with a valid Apple ID account.
+    More information can be found
+    in [this issue](https://github.com/RIMS-Code/RIMSEvalGUI/issues/9).
+    To still use the `RIMSEvaluation` executable,
+    open a terminal and type the following command:
+
+    .. code-block::
+
+        xattr -cr /Applications/RIMSEvaluation.app
+
+    This assumes that the program is in fact installed into
+    the main installation folder.
+    If not, replace ``/Applications/`` with the path to the correct
+    installation folder.
+    The `RIMSEvaluation` software should now run.
 
 --------
 Anaconda


### PR DESCRIPTION
Docs updated to help users on macOS that have issues with their computer claiming that the app is damaged and needs to be moved to trash. 

See also [this issue](https://github.com/RIMS-Code/RIMSEvalGUI/issues/9)