### PR TITLE
Improve coverage on Peirce criterion

### DIFF
--- a/tests/func/utilities/test_peirce.py
+++ b/tests/func/utilities/test_peirce.py
@@ -8,6 +8,16 @@ import numpy as np
 from rimseval.utilities import peirce
 
 
+def test_peirce_criterion_ldiv_zero():
+    """Choose a minimum ldiv if it is zero (erfc turns 0 at large values)."""
+    # define values such that it turns out to be zero
+    n_tot = 100
+    n = 1e3  # this brings `ldiv` numerically to zero
+    m = 1
+
+    _ = peirce.peirce_criterion(n_tot, n, m)
+
+
 @given(n_hyp=st.integers(), m_hyp=st.integers())
 def test_peirce_criterion_n_tot_zero(n_hyp, m_hyp):
     """Check that setting number of observations to zero returns zero always."""

--- a/tests/func/utilities/test_peirce.py
+++ b/tests/func/utilities/test_peirce.py
@@ -1,10 +1,33 @@
 """Test for Peirce criterion data rejection."""
 
 
+from hypothesis import given, strategies as st
 import pytest
 import numpy as np
 
 from rimseval.utilities import peirce
+
+
+@given(n_hyp=st.integers(), m_hyp=st.integers())
+def test_peirce_criterion_n_tot_zero(n_hyp, m_hyp):
+    """Check that setting number of observations to zero returns zero always."""
+    n_tot = 0
+    expected = 0
+    received = peirce.peirce_criterion(n_tot, n_hyp, m_hyp)
+    assert expected == received
+
+
+def test_peirce_criterion_x2_less_zero():
+    """Ensure that in while-loop, x2 is set to zero if it is smaller than zero."""
+    # define values that get x2 < 0
+    n_tot = 2
+    n = 1
+    m = 5
+
+    expected = 0
+    received = peirce.peirce_criterion(n_tot, n, m)
+
+    assert expected == received
 
 
 def test_peirce_ross_2003_example():


### PR DESCRIPTION
Still not all lines are covered, however, a few more are. See comment below.

Added coverage for special cases. The code was taken from Wikipedia and it passes with the test case scenario as stated before. I assume that the rest of the code is correct as well, and therefore add two tests to ensure that the code keeps on doing what it is supposed to in the future.
