### PR TITLE
Add a verbosity feature

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ Contents
     pkg/filters
     pkg/variables
     pkg/special
+    pkg/verbose
 
 .. toctree::
     :maxdepth: 2

--- a/docs/pkg/verbose.rst
+++ b/docs/pkg/verbose.rst
@@ -1,0 +1,17 @@
+=========
+Verbosity
+=========
+
+The package has the possibility to go into verbose mode.
+To do so, change the ``rimseval.DEBUG``.
+This variable is by default set to ``0``,
+which means no excessive warnings.
+
+Setting the debug level to ``1`` will show the following warnings in addition:
+
+- Automatic mass calibration optimization did not find enough peaks and was skipped.
+
+Setting the debug level to ``2`` will show the following warnings in addition:
+
+- Division by zero warnings in :math:`\delta`-value calculation
+- ``scipy`` optimize routine (peak fitting in mass calibration) reached maximum iterations.

--- a/rimseval/__init__.py
+++ b/rimseval/__init__.py
@@ -9,9 +9,12 @@ from . import utilities
 from .multi_proc import MultiFileProcessor
 from .processor import CRDFileProcessor
 
+VERBOSITY = 0
+
 ini = iniabu.IniAbu(database="nist")
 
 __all__ = [
+    "VERBOSITY",
     "ini",
     "CRDFileProcessor",
     "data_io",

--- a/rimseval/processor.py
+++ b/rimseval/processor.py
@@ -11,6 +11,7 @@ import warnings
 
 import numpy as np
 
+import rimseval
 from . import processor_utils
 from .data_io.crd_reader import CRDReader
 from .utilities import peirce, utils
@@ -753,9 +754,13 @@ class CRDFileProcessor:
 
         mcal_new = np.delete(mcal_new, index_to_del, axis=0)
         if len(mcal_new) < 2:
-            warnings.warn(
-                "Automatic mass calibration optimization did not find enough peaks."
-            )
+            if rimseval.VERBOSITY >= 1:
+                warnings.warn(
+                    "Automatic mass calibration optimization did not find enough "
+                    "peaks.",
+                    UserWarning,
+                )
+            return
         else:
             self.def_mcal = mcal_new
 

--- a/tests/unit/test_processor.py
+++ b/tests/unit/test_processor.py
@@ -327,3 +327,18 @@ def test_optimize_mcal(crd_data):
     crd.optimize_mcal()
 
     np.testing.assert_allclose(mcal_input, crd.def_mcal, rtol=0.01)
+
+
+def test_optimize_mcal_verbosity_warnings(crd_data):
+    """Warn user in mass calibration at verbosity levels >= 1."""
+    rimseval.VERBOSITY = 1
+    fname = crd_data.joinpath("ti_standard_01.crd")
+    # input with peaks intentianlly off
+    mcal_input = np.array([[1.01150472, 45.95262772], [1.24462075, 46.95175879]])
+    crd = CRDFileProcessor(fname)
+    crd.spectrum_full()
+    crd.def_mcal = mcal_input
+    crd.mass_calibration()
+
+    with pytest.warns(UserWarning):
+        crd.optimize_mcal()


### PR DESCRIPTION
Verbosity can now be set using the `rimseval.VERBOSITY` levels. If it is set to 0, then only useful warnings should be displayed to the user. This feature should help with debugging in the future, i.e., when a error / warning is given out while using the program in non-installer mode, it actually means something.