### PR TITLE
Fix lint

### DIFF
--- a/rimseval/processor_utils.py
+++ b/rimseval/processor_utils.py
@@ -143,7 +143,7 @@ def delta_calc(names: List[str], integrals: np.ndarray) -> np.ndarray:
             maj = ini._get_norm_iso(ele)  # can't give index error if above passed
             norm_iso_name.append(maj)
 
-    integrals_dict = dict(zip(names_iniabu, range(len(names_iniabu))))
+    integrals_dict = dict(zip(names_iniabu, range(len(names_iniabu))))  # noqa: B905
 
     integrals_delta = np.zeros_like(integrals, dtype=float)
 


### PR DESCRIPTION
Ignore strictness requirement on `zip`, requires `py>3.8`
