### PR TITLE
Drop black, remove flake8, bandit restrictions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ description-file = "README.rst"
 
 [tool.flit.metadata.requires-extra]
 dev = [
-    "black",
     "darglint>=1.5.1",
     "flake8",
     "flake8-bandit",


### PR DESCRIPTION
Black restriction is bad. could be dropped altogether in nox since it is not really used anymore and implemented as a pre-commit hook.

Flake8 and bandit issues are resolved with latest versions, drop version pinning to old versions﻿
