### PR TITLE
Export integrals to file

### DIFF
--- a/docs/dev/api/data_io.rst
+++ b/docs/dev/api/data_io.rst
@@ -113,6 +113,26 @@ Excel Writer
 
 
 
+.. py:currentmodule:: rimseval.data_io.integrals
+
+------------------------
+Integral export / import
+------------------------
+
+**************
+:func:`export`
+**************
+
+.. autofunction:: export
+
+************
+:func:`load`
+************
+
+.. autofunction:: mass_spectrum
+
+
+
 .. py:currentmodule:: rimseval.data_io.export
 
 ----------------

--- a/rimseval/data_io/__init__.py
+++ b/rimseval/data_io/__init__.py
@@ -6,8 +6,9 @@ the `docs` folder and adheres currently to v1.0 of the format.
 
 from . import crd_utils
 from . import export
+from . import integrals
 from . import lst_utils
 from .crd_reader import CRDReader
 from .lst_to_crd import LST2CRD
 
-__all__ = ["export", "crd_utils", "lst_utils", "CRDReader", "LST2CRD"]
+__all__ = ["export", "crd_utils", "integrals", "lst_utils", "CRDReader", "LST2CRD"]

--- a/rimseval/data_io/integrals.py
+++ b/rimseval/data_io/integrals.py
@@ -1,0 +1,81 @@
+"""Handle import and export of integrals."""
+
+import datetime
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+
+from rimseval.processor import CRDFileProcessor
+
+
+def export(crd: CRDFileProcessor, fname: Path = None) -> None:
+    """Export integrals to csv file.
+
+    If no file name is given, the file name of the CRD file is used, '_int' is added,
+    and '.csv' is used as the extension.
+
+    Header lines start with a #, all data lines are comma separated and labels for
+    rows and columns are given within the data.
+
+    :param crd: CRD file.
+    :param fname: File name to export to (optional): csv file.
+
+    :raises ValueError: CRD file has no integrals.
+    """
+
+    if crd.integrals is None:
+        raise ValueError("CRD file has no integrals.")
+
+    if fname is None:
+        fname = (
+            crd.fname.with_name(crd.fname.stem + "_int").with_suffix(".csv").absolute()
+        )
+    else:
+        if not fname.suffix == ".csv":
+            fname = fname.with_suffix(".csv").absolute()
+
+    peak_names = crd.def_integrals[0]
+
+    with open(fname, "w") as f:
+        f.write(f"# CRD File: {crd.name}\n")
+        f.write(f"# Timestamp: {crd.timestamp}\n")
+        f.write("Peak,Integral,Error\n")
+        for it, peak in enumerate(peak_names):
+            f.write(f"{peak},{crd.integrals[it][0]},{crd.integrals[it][1]}\n")
+
+
+def load(fname: Path) -> Tuple[str, datetime.datetime, List, np.ndarray]:
+    """Load an integral csv file.
+
+    :param fname: File name to load from.
+
+    :return: Integral data.
+        1. CRD file name (equiv to ``crd.name``)
+        2. Timestamp (equiv to ``crd.timestamp``)
+        3. Peak names (equiv to ``crd.def_integrals[0]``)
+        4. Integrals (equiv to ``crd.integrals``)
+    """
+    with open(fname) as f:
+        lines = f.readlines()
+
+    crd_name = None
+    timestamp = None
+
+    for it, line in enumerate(lines):
+        if line[0] == "#":  # header
+            if line.startswith("# CRD File:"):
+                crd_name = line.split(":")[1].strip()
+            if line.startswith("# Timestamp:"):
+                tmp = line.split(":")[1:]
+                timestamp = datetime.datetime.strptime(
+                    ":".join(tmp).strip(), "%Y-%m-%d %H:%M:%S"
+                )
+
+    peak_names = []
+    integrals = []
+    for line in lines[3:]:
+        peak_names.append(line.split(",")[0])
+        integrals.append([float(line.split(",")[1]), float(line.split(",")[2])])
+
+    return crd_name, timestamp, peak_names, np.array(integrals)

--- a/rimseval/data_io/integrals.py
+++ b/rimseval/data_io/integrals.py
@@ -11,7 +11,6 @@ from rimseval.processor import CRDFileProcessor
 
 def export(crd: CRDFileProcessor, fname: Path = None) -> None:
     """Export integrals to csv file.
-
     If no file name is given, the file name of the CRD file is used, '_int' is added,
     and '.csv' is used as the extension.
 
@@ -62,7 +61,7 @@ def load(fname: Path) -> Tuple[str, datetime.datetime, List, np.ndarray]:
     crd_name = None
     timestamp = None
 
-    for it, line in enumerate(lines):
+    for line in lines:
         if line[0] == "#":  # header
             if line.startswith("# CRD File:"):
                 crd_name = line.split(":")[1].strip()

--- a/rimseval/data_io/integrals.py
+++ b/rimseval/data_io/integrals.py
@@ -11,6 +11,7 @@ from rimseval.processor import CRDFileProcessor
 
 def export(crd: CRDFileProcessor, fname: Path = None) -> None:
     """Export integrals to csv file.
+
     If no file name is given, the file name of the CRD file is used, '_int' is added,
     and '.csv' is used as the extension.
 
@@ -22,7 +23,6 @@ def export(crd: CRDFileProcessor, fname: Path = None) -> None:
 
     :raises ValueError: CRD file has no integrals.
     """
-
     if crd.integrals is None:
         raise ValueError("CRD file has no integrals.")
 

--- a/rimseval/processor.py
+++ b/rimseval/processor.py
@@ -208,6 +208,11 @@ class CRDFileProcessor:
         return processor_utils.check_peaks_overlap(self.def_integrals[1])
 
     @property
+    def name(self):
+        """Get the name of the CRD file."""
+        return self.fname.name
+
+    @property
     def peak_fwhm(self) -> float:
         """Get / Set the FWHM of the peak.
 

--- a/tests/func/data_io/conftest.py
+++ b/tests/func/data_io/conftest.py
@@ -1,6 +1,9 @@
 """PyTest fixtures for func tests in data_io."""
 
+from pathlib import Path
+
 import pytest
+import numpy as np
 
 import rimseval
 
@@ -28,3 +31,20 @@ def mpa4a_data_ascii():
         "000a00b95a54",
     ]
     return channel, fmt, data
+
+
+@pytest.fixture
+def crdproc_int(crd_file) -> rimseval.processor.CRDFileProcessor:
+    """Provides a dummy CRDProcessor file with integrals.
+
+    :return: Dummy CRDProcessor file with integrals.
+    """
+    _, _, _, fname = crd_file
+    crd = rimseval.processor.CRDFileProcessor(Path(fname))
+    crd.spectrum_full()
+    crd.def_mcal = np.array([[1, 2], [10, 20]])
+    crd.mass_calibration()
+    crd.def_integrals = ["Int1", "Int2"], np.array([[1, 2], [3, 4]])
+    crd.integrals = np.array([[103, 104], [203, 204]])
+
+    return crd

--- a/tests/func/data_io/test_integrals.py
+++ b/tests/func/data_io/test_integrals.py
@@ -1,0 +1,42 @@
+"""Functional tests for the data_io integrals module."""
+
+from pathlib import Path
+
+import pytest
+import numpy as np
+
+from rimseval.data_io import integrals
+
+
+def test_export(crdproc_int):
+    """Export of integrals with default filename."""
+    integrals.export(crdproc_int)
+    fname = Path(crdproc_int.fname)
+    fname = fname.with_name(fname.stem + "_int").with_suffix(".csv").absolute()
+    assert fname.is_file()
+
+
+def test_export_fname(crdproc_int, tmpdir):
+    """Export of integrals with given filename."""
+    fname = Path(tmpdir.strpath).joinpath("test")
+    integrals.export(crdproc_int, fname)
+    assert fname.with_suffix(".csv").is_file()
+
+
+def test_export_valueerror(crdproc_int):
+    """Export of integrals with CRDProcessor class with no integrals."""
+    crdproc_int.integrals = None
+    with pytest.raises(ValueError):
+        integrals.export(crdproc_int)
+
+
+def test_load(crdproc_int, tmpdir):
+    """Assure that export and load end up with the same data."""
+    fname = Path(tmpdir.strpath).joinpath("test.csv")
+    integrals.export(crdproc_int, fname)
+    name_ld, timestamp_ld, peaks_ld, int_ld = integrals.load(fname)
+
+    assert name_ld == crdproc_int.name
+    assert timestamp_ld == crdproc_int.timestamp
+    assert peaks_ld == crdproc_int.def_integrals[0]
+    np.testing.assert_allclose(int_ld, crdproc_int.integrals)

--- a/tests/func/test_processor.py
+++ b/tests/func/test_processor.py
@@ -23,6 +23,15 @@ def test_integrals_overlap(crd_file):
     assert not crd.integrals_overlap
 
 
+def test_name(crd_file):
+    """Get the filename of the input file."""
+    _, _, _, fname = crd_file
+    crd = CRDFileProcessor(Path(fname))
+    name = crd.name
+    assert name == Path(fname).name
+    assert isinstance(name, str)
+
+
 def test_timestamp(crd_file):
     """Get the time stamp of the CRD file as a python datetime."""
     _, _, _, fname = crd_file


### PR DESCRIPTION
This PR enables the possibility to export the integrals of one specific CRDProcessor file to a `csv` file. This might not be very useful for routine operations, however, will be used in the whole evaluator (to be written). Users might prefer to continue to use the function to "Write as Excel Workup File" for now.

- add name property to processor to get the filename
- Single file integral export / import routine
