### PR TITLE
Upgrade numba to 0.57.1

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [report]
-omit = */guis/*
-omit = noxfile.py
+omit =
+        */guis/*
+        noxfile.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [report]
 omit = */guis/*
+omit = noxfile.py

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/rimseval_testing.yml
+++ b/.github/workflows/rimseval_testing.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 *.sublime-project
 *.sublime-workspace
 
+# VSCode
+.vscode
+
 ## temporary files and folders ##
 temp
 tmp

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,13 +2,12 @@
 
 import nox
 
-# fixme: add safety to nox
 nox.options.sessions = ["lint", "tests"]
 
 package = "rimseval"
 locations = "rimseval", "noxfile.py"
-python_default = "3.10"
-python_suite = ["3.10", "3.9", "3.8"]
+python_default = "3.11"
+python_suite = ["3.11", "3.10", "3.9", "3.8"]
 
 
 @nox.session(python=python_default)
@@ -34,14 +33,3 @@ def tests(session):
     """Test the project using ``pytest``."""
     session.install(".[test]")
     session.run("pytest")
-
-
-@nox.session(python=python_default)
-def safety(session):
-    """Safety check for all dependencies."""
-    session.install("safety", ".")
-    session.run(
-        "safety",
-        "check",
-        "--full-report",
-    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,15 @@ author = "Reto Trappitsch"
 author-email = "reto@galactic-forensics.space"
 home-page = "https://github.com/RIMS-Code/RIMSEval"
 requires = [
-    "iniabu>=1.1.1",
+    "iniabu>=1.1.2",
     "matplotlib",
-    "numba~=0.56.4",
-    "numpy~=1.23.5",
+    "numba~=0.57.1",
+    "numpy~=1.24.4",
     "PyQt6",
     "scipy",
     "xlsxwriter"
 ]
-requires-python=">=3.8"
+requires-python=">=3.8,<3.12"
 classifiers = [ "License :: OSI Approved :: MIT License",]
 description-file = "README.rst"
 


### PR DESCRIPTION
Upgraded `numba` to the latest version and add support for python 3.11. 
Pinned the `numpy` repositories according to `numba` requirements and requiering the latest `iniabu` module now, such that it actually runs on the current `numpy` that is compatible with `py311`.
