### PR TITLE
BF: pypi release workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flit flit-scm setuptools-scm
+        pip install .
     - name: Build and publish
       env:
         FLIT_USERNAME: '__token__'


### PR DESCRIPTION
Add self installation to the workflow, since it previously failed when trying to release `v2.0.2`
